### PR TITLE
almost json parser and config

### DIFF
--- a/fluentbit-almost-json.conf
+++ b/fluentbit-almost-json.conf
@@ -1,0 +1,20 @@
+[INPUT]
+    # when tailing a file, the Name should always be 'tail'. It's not really a name, more of a input type.
+    Name tail
+    # Path of the file to be tailed.
+    Path /etc/newrelic-infra/logging.d/json.log
+    # Path_Key adds the filepath and filename to each log record so you can see the source. 
+    ## This comes in by default when (only) using a .yml file for logging.
+    Path_Key filename
+    # just increasing the buffer here, may not be needed for a lower number of files.
+    Buffer_Max_Size 128k
+    # The parser we're using is below, named almost.json
+    Parser almost.json
+    # The DB is where FB keeps track of what it has processed thus far.
+    DB   /var/db/newrelic-infra/newrelic-integrations/logging/fb.db
+
+# This [FILTER] clause is so we can add attributes to the log records in a attribute <space> value format
+[FILTER]
+    Name record_modifier
+    Match *.*
+    Record attribute value.here

--- a/parsers-almost-json.conf
+++ b/parsers-almost-json.conf
@@ -1,0 +1,4 @@
+[PARSER]
+    Name        almost.json
+    Format      regex
+    Regex       ^[^{]*(?<message>.*)$


### PR DESCRIPTION
Adding this example to the fluentbit examples repo. This situation comes up in AWS environments where the logs are almost json, but have some text in the beginning of the log record making it an incomplete json payload.

This parser will strip out the beginning text and write the json payload to the message field so it can automatically be parsed by NR.